### PR TITLE
Fix add_library STATIC eating other arguments

### DIFF
--- a/fixture/commands/project/add_library
+++ b/fixture/commands/project/add_library
@@ -1,4 +1,5 @@
 add_library(MyProgram STATIC EXCLUDE_FROM_ALL my_program.cpp)
+add_library(MyStaticProgram STATIC my_static_program.cpp)
 add_library(ClangFormat UNKNOWN IMPORTED GLOBAL)
 add_library(MyAliasedProgram ALIAS MyProgram)
 add_library(MyInterfaceLib INTERFACE)

--- a/lib/src/doc/command/project/add_library.rs
+++ b/lib/src/doc/command/project/add_library.rs
@@ -48,7 +48,7 @@ pub struct InterfaceLibrary<'t> {
 }
 
 #[derive(CMake, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cmake(pkg = "crate", default = "sources")]
+#[cmake(pkg = "crate", default = "sources", positional)]
 pub struct NormalLibrary<'t> {
     pub library_type: Option<NormalLibraryType>,
     pub exclude_from_all: bool,
@@ -107,6 +107,14 @@ mod tests {
                         library_type: Some(NormalLibraryType::Static),
                         exclude_from_all: true,
                         sources: Some(vec![b"my_program.cpp".into()])
+                    })
+                })),
+                Command::AddLibrary(Box::new(AddLibrary {
+                    name: b"MyStaticProgram".into(),
+                    library: Library::Normal(NormalLibrary {
+                        library_type: Some(NormalLibraryType::Static),
+                        exclude_from_all: false,
+                        sources: Some(vec![b"my_static_program.cpp".into()])
                     })
                 })),
                 Command::AddLibrary(Box::new(AddLibrary {


### PR DESCRIPTION
Fixes https://github.com/rust-utility/cmake-parser/issues/4.

I believe this is the correct fix, although the proc macro used for parsing totally eludes me, so this is just a best guess.

It passes the test I added and no other tests break, so I guess it works?